### PR TITLE
Exposing onRowsDelete in customToolbarSelect

### DIFF
--- a/examples/customize-toolbarselect/CustomToolbarSelect.js
+++ b/examples/customize-toolbarselect/CustomToolbarSelect.js
@@ -5,6 +5,7 @@ import CompareArrowsIcon from "@material-ui/icons/CompareArrows";
 import IndeterminateCheckBoxIcon from "@material-ui/icons/IndeterminateCheckBox";
 import BlockIcon from "@material-ui/icons/Block";
 import { withStyles } from "@material-ui/core/styles";
+import DeleteIcon from '@material-ui/icons/Delete';
 
 const defaultToolbarSelectStyles = {
   iconButton: {
@@ -38,6 +39,10 @@ class CustomToolbarSelect extends React.Component {
     console.log(`block users with dataIndexes: ${this.props.selectedRows.data.map(row => row.dataIndex)}`);
   };
 
+  handleDelete = () => {
+    this.props.onRowsDelete();
+  };
+
   render() {
     const { classes } = this.props;
 
@@ -56,6 +61,11 @@ class CustomToolbarSelect extends React.Component {
         <Tooltip title={"Block selected"}>
           <IconButton className={classes.iconButton} onClick={this.handleClickBlockSelected}>
             <BlockIcon className={classes.icon} />
+          </IconButton>
+        </Tooltip>
+        <Tooltip title={"Delete selected"}>
+          <IconButton className={classes.iconButton} onClick={this.handleDelete}>
+            <DeleteIcon className={classes.icon} />
           </IconButton>
         </Tooltip>
       </div>

--- a/examples/customize-toolbarselect/index.js
+++ b/examples/customize-toolbarselect/index.js
@@ -55,8 +55,8 @@ function Example() {
     responsive: "vertical",
     rowsPerPage: 10,
     selectToolbarPlacement: stp,
-    customToolbarSelect: (selectedRows, displayData, setSelectedRows) => (
-      <CustomToolbarSelect selectedRows={selectedRows} displayData={displayData} setSelectedRows={setSelectedRows} />
+    customToolbarSelect: (selectedRows, displayData, setSelectedRows, onRowsDelete) => (
+      <CustomToolbarSelect selectedRows={selectedRows} displayData={displayData} setSelectedRows={setSelectedRows} onRowsDelete={onRowsDelete} />
     ),
   };
 

--- a/src/components/TableToolbarSelect.js
+++ b/src/components/TableToolbarSelect.js
@@ -75,7 +75,7 @@ class TableToolbarSelect extends React.Component {
           </Typography>
         </div>
         {options.customToolbarSelect ? (
-          options.customToolbarSelect(selectedRows, displayData, this.handleCustomSelectedRows)
+          options.customToolbarSelect(selectedRows, displayData, this.handleCustomSelectedRows, onRowsDelete)
         ) : (
           <Tooltip title={textLabels.delete}>
             <IconButton className={classes.iconButton} onClick={onRowsDelete} aria-label={textLabels.deleteAria}>

--- a/test/MUIDataTableToolbarSelect.test.js
+++ b/test/MUIDataTableToolbarSelect.test.js
@@ -23,7 +23,7 @@ describe('<TableToolbarSelect />', function() {
     assert.strictEqual(actualResult.length, 1);
   });
 
-  it('should call customToolbarSelect with 3 arguments', () => {
+  it('should call customToolbarSelect with 4 arguments', () => {
     const onRowsDelete = () => {};
     const customToolbarSelect = spy();
     const selectedRows = { data: [1] };
@@ -38,7 +38,7 @@ describe('<TableToolbarSelect />', function() {
       />,
     );
 
-    assert.strictEqual(customToolbarSelect.calledWith(selectedRows, displayData, match.typeOf('function')), true);
+    assert.strictEqual(customToolbarSelect.calledWith(selectedRows, displayData, match.typeOf('function'), match.typeOf('function')), true);
   });
 
   it('should throw TypeError if selectedRows is not an array of numbers', done => {


### PR DESCRIPTION
Fixing https://github.com/gregnb/mui-datatables/issues/544 by exposing the onRowsDelete function to customToolbarSelect which can be used to delete rows in the table